### PR TITLE
Fix downloads from the video player

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/VideoDownloadDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/VideoDownloadDialog.kt
@@ -101,25 +101,34 @@ class VideoDownloadDialog : BaseDownloadDialog() {
                             0
                         } else {
                             val min = from - targetDuration
-                            relativeStartTimes.binarySearch(comparison = { time ->
+                            val tmpIndex = relativeStartTimes.binarySearch(comparison = { time ->
                                 when {
                                     time > from -> 1
                                     time < min -> -1
                                     else -> 0
                                 }
                             })
+                            /***
+                             * If the item is not found by the binarySearch method, it will return a
+                             * negative value and the app will crash. On that case, the function
+                             * returns the inverted insertion point (-insertion point - 1).
+                             * */
+                            if (tmpIndex < 0) -tmpIndex else tmpIndex
+
                         }
                         val toIndex = if (to in relativeStartTimes.last()..totalDuration) {
                             relativeStartTimes.lastIndex
                         } else {
                             val max = to + targetDuration
-                            relativeStartTimes.binarySearch(comparison = { time ->
+                            val tmpIndex= relativeStartTimes.binarySearch(comparison = { time ->
                                 when {
                                     time > max -> 1
                                     time < to -> -1
                                     else -> 0
                                 }
                             })
+                            //Apply the same check to the toIndex result
+                            if (tmpIndex < 0) -tmpIndex else tmpIndex
                         }
                         fun startDownload() {
                             val quality = spinner.selectedItem.toString()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipPlayerFragment.kt
@@ -129,9 +129,7 @@ class ClipPlayerFragment : BasePlayerFragment(), HasDownloadDialog, ChatReplayPl
     }
 
     override fun showDownloadDialog() {
-        if (DownloadUtils.hasStoragePermission(requireActivity())) {
-            ClipDownloadDialog.newInstance(clip, viewModel.qualities).show(childFragmentManager, null)
-        }
+        ClipDownloadDialog.newInstance(clip, viewModel.qualities).show(childFragmentManager, null)
     }
 
     override fun onMovedToForeground() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/video/VideoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/video/VideoPlayerFragment.kt
@@ -159,9 +159,7 @@ class VideoPlayerFragment : BasePlayerFragment(), HasDownloadDialog, ChatReplayP
     }
 
     override fun showDownloadDialog() {
-        if (DownloadUtils.hasStoragePermission(requireActivity())) {
-            viewModel.videoInfo?.let { VideoDownloadDialog.newInstance(it).show(childFragmentManager, null) }
-        }
+        viewModel.videoInfo?.let { VideoDownloadDialog.newInstance(it).show(childFragmentManager, null) }
     }
 
     override fun onMovedToForeground() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/DownloadUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/DownloadUtils.kt
@@ -1,15 +1,10 @@
 package com.github.andreyasadchy.xtra.util
 
-import android.Manifest
-import android.app.Activity
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.os.Environment
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
@@ -105,28 +100,6 @@ object DownloadUtils {
         }
     }
 
-    fun hasStoragePermission(activity: Activity): Boolean {
-        fun requestPermissions() {
-            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE), 0)
-        }
-
-        if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ||
-                ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-            return true
-        }
-        if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            AlertDialog.Builder(activity)
-                    .setMessage(R.string.storage_permission_message)
-                    .setTitle(R.string.storage_permission_title)
-                    .setPositiveButton(android.R.string.ok) { _, _ -> requestPermissions() }
-                    .setNegativeButton(android.R.string.cancel) { _, _ -> activity.toast(R.string.permission_denied) }
-                    .show()
-        } else {
-            requestPermissions()
-        }
-        return false
-    }
 
     fun getAvailableStorage(context: Context): List<Storage> {
         val storage = ContextCompat.getExternalFilesDirs(context, ".downloads")


### PR DESCRIPTION
Trying to download a VoD or a clip from the video player causes the app to throw an error of missing permissions.

The app no longer uses nor asks for that permission since, the download location is inside the storage of the app (android/data/...). But on those two cases, the app checks the old permissions. Moreover, the old permissions are no longer accessible on Android 13 (Scoped storage).

This change fixes the issue by removing the unnecessary checks and fixes a crash causes by an unhandled result of the process to calculate the start time (index) for the download. (Documented on the code.)

This PR fixes #208
