### PR TITLE
Add the ability to view open source licenses from the settings screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id("kotlin-kapt")
     id("dagger.hilt.android.plugin")
     id("com.apollographql.apollo3").version("$apollo_ver")
+    id("com.mikepenz.aboutlibraries.plugin")
 }
 
 android {
@@ -124,6 +125,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+
+    implementation "com.mikepenz:aboutlibraries:10.5.2"
 }
 
 apollo {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <data android:host="twitch.tv" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.settings.OpenSourceLicensesActivity"/>
         <activity android:name=".ui.settings.SettingsActivity"/>
         <activity
             android:name=".ui.login.LoginActivity"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/OpenSourceLicensesActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/OpenSourceLicensesActivity.kt
@@ -1,0 +1,22 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.ui.Utils
+import com.github.andreyasadchy.xtra.util.applyTheme
+import com.mikepenz.aboutlibraries.LibsBuilder
+
+class OpenSourceLicensesActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        applyTheme()
+        setContentView(R.layout.activity_open_source_licenses)
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar.navigationIcon = Utils.getNavigationIcon(this)
+        toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+        val fragment = LibsBuilder().supportFragment()
+        supportFragmentManager.beginTransaction().replace(R.id.open_source_licenses, fragment).commit()
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -16,6 +16,7 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.ui.Utils
 import com.github.andreyasadchy.xtra.ui.settings.api.DragListFragment
 import com.github.andreyasadchy.xtra.util.*
+import com.mikepenz.aboutlibraries.LibsBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.activity_settings.*
 
@@ -206,6 +207,14 @@ class SettingsActivity : AppCompatActivity() {
 
             findPreference<Preference>("admin_settings")?.setOnPreferenceClickListener {
                 startActivity(Intent().setComponent(ComponentName("com.android.settings", "com.android.settings.DeviceAdminSettings")))
+                true
+            }
+
+            findPreference<Preference>("open_source_licenses_settings")?.setOnPreferenceClickListener {
+                LibsBuilder()
+                    .withActivityTitle(getString(R.string.open_source_licences))
+                    .withSearchEnabled(true)
+                    .start(requireActivity())
                 true
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -16,7 +16,6 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.ui.Utils
 import com.github.andreyasadchy.xtra.ui.settings.api.DragListFragment
 import com.github.andreyasadchy.xtra.util.*
-import com.mikepenz.aboutlibraries.LibsBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.activity_settings.*
 
@@ -211,10 +210,7 @@ class SettingsActivity : AppCompatActivity() {
             }
 
             findPreference<Preference>("open_source_licenses_settings")?.setOnPreferenceClickListener {
-                LibsBuilder()
-                    .withActivityTitle(getString(R.string.open_source_licences))
-                    .withSearchEnabled(true)
-                    .start(requireActivity())
+                startActivity(Intent(requireContext(), OpenSourceLicensesActivity::class.java))
                 true
             }
         }

--- a/app/src/main/res/layout/activity_open_source_licenses.xml
+++ b/app/src/main/res/layout/activity_open_source_licenses.xml
@@ -1,0 +1,18 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:title="@string/open_source_licences" />
+
+    <FrameLayout
+        android:id="@+id/open_source_licenses"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,8 @@
     <string name="show_clearchat">Show timeouts and bans</string>
     <string name="player_gamesbutton">Show games button on vods</string>
     <string name="copy_fullmsg">Copy full message</string>
+    <string name="settings_other">OTHER</string>
+    <string name="open_source_licences">Open source licenses</string>
     <string name="settings_debug">DEBUG</string>
     <string name="show_copy_fullmsg">Copy full IRC messages</string>
     <string name="chat_disconnect">Disconnecting from %1$s - %2$s</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="BaseDarkTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="BaseDarkTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge">
         <item name="colorAccent">@color/accent</item>
         <item name="primaryColor">@color/primaryDark</item>
         <item name="textColor">@android:color/white</item>
@@ -21,7 +21,7 @@
         <item name="preferenceTheme">@style/prefDark</item>
     </style>
 
-    <style name="BaseLightTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="BaseLightTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorAccent">@color/accent</item>
         <item name="primaryColor">@color/primaryLight</item>
         <item name="textColor">@android:color/black</item>
@@ -44,7 +44,7 @@
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
     </style>
 
-    <style name="BaseAmoledTheme" parent="Theme.AppCompat.NoActionBar" >
+    <style name="BaseAmoledTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge" >
         <item name="colorAccent">@android:color/white</item>
         <item name="primaryColor">@android:color/black</item>
         <item name="textColor">@android:color/white</item>
@@ -65,7 +65,7 @@
         <item name="preferenceTheme">@style/prefDark</item>
     </style>
 
-    <style name="BaseBlueTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="BaseBlueTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge">
         <item name="colorAccent">@color/accent</item>
         <item name="primaryColor">@color/primaryBlue</item>
         <item name="textColor">@android:color/white</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,7 @@
         <item name="radioButtonStyle">@style/RadioButton</item>
         <item name="chatStatus">@color/chatStatusDark</item>
         <item name="preferenceTheme">@style/prefDark</item>
+        <item name="aboutLibrariesStyle">@style/CustomAboutLibrariesStyle</item>
     </style>
 
     <style name="BaseLightTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -42,6 +43,7 @@
         <item name="preferenceTheme">@style/prefLight</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="aboutLibrariesStyle">@style/CustomAboutLibrariesStyle</item>
     </style>
 
     <style name="BaseAmoledTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge" >
@@ -63,6 +65,7 @@
         <item name="radioButtonStyle">@style/RadioButton</item>
         <item name="chatStatus">@color/chatStatusDark</item>
         <item name="preferenceTheme">@style/prefDark</item>
+        <item name="aboutLibrariesStyle">@style/CustomAboutLibrariesStyle</item>
     </style>
 
     <style name="BaseBlueTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge">
@@ -84,6 +87,7 @@
         <item name="radioButtonStyle">@style/RadioButton</item>
         <item name="chatStatus">@color/chatStatusDark</item>
         <item name="preferenceTheme">@style/prefDark</item>
+        <item name="aboutLibrariesStyle">@style/CustomAboutLibrariesStyle</item>
     </style>
 
     <style name="DarkTheme" parent="BaseDarkTheme" />
@@ -273,6 +277,15 @@
 
     <style name="prefLight" parent="@style/PreferenceThemeOverlay.v14.Material">
         <item name="android:tint">@android:color/black</item>
+    </style>
+
+    <style name="CustomAboutLibrariesStyle" parent="">
+        <item name="aboutLibrariesCardBackground">?attr/primaryColor</item>
+        <item name="aboutLibrariesDescriptionTitle">?android:textColorPrimary</item>
+        <item name="aboutLibrariesDescriptionText">?android:textColorSecondary</item>
+        <item name="aboutLibrariesOpenSourceTitle">?android:textColorPrimary</item>
+        <item name="aboutLibrariesOpenSourceText">?android:textColorSecondary</item>
+        <item name="aboutLibrariesSpecialButtonText">?android:textColorPrimary</item>
     </style>
 
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -453,6 +453,13 @@
         app:min="1"
         app:showSeekBarValue="true" />
 
+    <PreferenceCategory android:title="@string/settings_other" app:iconSpaceReserved="false"/>
+
+    <Preference
+        android:key="open_source_licenses_settings"
+        android:title="@string/open_source_licences"
+        app:iconSpaceReserved="false" />
+
     <PreferenceCategory android:title="@string/settings_debug" app:iconSpaceReserved="false"/>
     <SwitchPreferenceCompat
         android:defaultValue="false"

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,13 @@ buildscript {
         google()
         mavenCentral()
         jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger"
+        classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.5.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Given that this is an Open Source app it seems only fitting (and an obligation for most of the libraries used) to include a page where you can view the libraries and associated licenses used in this application.

https://user-images.githubusercontent.com/2296196/220281550-3ca42220-233d-4afe-9fab-46df6f1e3e07.mp4

