### PR TITLE
Fix playback reset on audio to video

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt
@@ -54,6 +54,7 @@ abstract class HlsPlayerViewModel(
                 releasePlayer()
                 initializePlayer()
                 play()
+                player?.seekTo(playbackPosition)
             } else {
                 restartPlayer()
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/video/VideoPlayerViewModel.kt
@@ -148,9 +148,6 @@ class VideoPlayerViewModel @Inject constructor(
                         player?.currentPosition?.let { playbackPosition = it }
                     }
                     setVideoQuality(index)
-                    if (audioOnly) {
-                        player?.seekTo(playbackPosition)
-                    }
                 }
                 index == qualities.lastIndex -> startAudioOnly(quality = previousQuality)
             }


### PR DESCRIPTION
Fixes #256 
The issue was that the player was reset here:
https://github.com/crackededed/Xtra/blob/9547111e91936e32f9bad2a3d7f600efdfdcdb7b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt#L52-L56
And then the playback position was lost when later it changed the quality and read it from the new player here:
https://github.com/crackededed/Xtra/blob/9547111e91936e32f9bad2a3d7f600efdfdcdb7b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt#L94