### PR TITLE
Center emotes vertically in chat

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
@@ -36,6 +36,7 @@ import com.github.andreyasadchy.xtra.model.chat.LiveChatMessage
 import com.github.andreyasadchy.xtra.model.chat.PubSubPointReward
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
+import com.github.andreyasadchy.xtra.ui.view.chat.CenteredImageSpan
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import java.util.Random
 import kotlin.collections.set
@@ -404,7 +405,7 @@ class ChatAdapter(
                         (result as Animatable).start()
                     }
                     try {
-                        builder.setSpan(ImageSpan(result), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
+                        builder.setSpan(CenteredImageSpan(result), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
                     } catch (e: IndexOutOfBoundsException) {
                     }
                     holder.bind(originalMessage, builder, userId, channelId, fullMsg)
@@ -452,7 +453,7 @@ class ChatAdapter(
                         (resource as Animatable).start()
                     }
                     try {
-                        builder.setSpan(ImageSpan(resource), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
+                        builder.setSpan(CenteredImageSpan(resource), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
                     } catch (e: IndexOutOfBoundsException) {
                     }
                     holder.bind(originalMessage, builder, userId, channelId, fullMsg)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/CenteredImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/CenteredImageSpan.kt
@@ -1,0 +1,70 @@
+package com.github.andreyasadchy.xtra.ui.view.chat
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Paint.FontMetricsInt
+import android.graphics.drawable.Drawable
+import android.text.style.ImageSpan
+import java.lang.ref.WeakReference
+
+class CenteredImageSpan( drawable: Drawable) : ImageSpan(
+     drawable
+) {
+    private var mDrawableRef: WeakReference<Drawable?>? = null
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fm: FontMetricsInt?
+    ): Int {
+        val d = cachedDrawable
+        val rect = d!!.bounds
+        if (fm != null) {
+            val pfm = paint.fontMetricsInt
+            // keep it the same as paint's fm
+            fm.ascent = pfm.ascent
+            fm.descent = pfm.descent
+            fm.top = pfm.top
+            fm.bottom = pfm.bottom
+        }
+        return rect.right
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        val b = cachedDrawable
+        canvas.save()
+        val drawableHeight = b!!.intrinsicHeight
+        val fontAscent = paint.fontMetricsInt.ascent
+        val fontDescent = paint.fontMetricsInt.descent
+        val transY = bottom - b.bounds.bottom +  // align bottom to bottom
+                (drawableHeight - fontDescent + fontAscent) / 2 // align center to center
+        canvas.translate(x, transY.toFloat())
+        b.draw(canvas)
+        canvas.restore()
+    }
+
+    // Redefined locally because it is a private member from DynamicDrawableSpan
+    private val cachedDrawable: Drawable?
+        private get() {
+            val wr = mDrawableRef
+            var d: Drawable? = null
+            if (wr != null) d = wr.get()
+            if (d == null) {
+                d = drawable
+                mDrawableRef = WeakReference(d)
+            }
+            return d
+        }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/CenteredImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/CenteredImageSpan.kt
@@ -1,6 +1,5 @@
 package com.github.andreyasadchy.xtra.ui.view.chat
 
-import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Paint.FontMetricsInt
@@ -8,56 +7,47 @@ import android.graphics.drawable.Drawable
 import android.text.style.ImageSpan
 import java.lang.ref.WeakReference
 
-class CenteredImageSpan( drawable: Drawable) : ImageSpan(
-     drawable
+
+class CenteredImageSpan(drawable: Drawable) : ImageSpan(
+    drawable
 ) {
     private var mDrawableRef: WeakReference<Drawable?>? = null
     override fun getSize(
-        paint: Paint,
-        text: CharSequence,
-        start: Int,
-        end: Int,
-        fm: FontMetricsInt?
+        paint: Paint, text: CharSequence?, start: Int, end: Int,
+        fontMetricsInt: FontMetricsInt?
     ): Int {
-        val d = cachedDrawable
-        val rect = d!!.bounds
-        if (fm != null) {
-            val pfm = paint.fontMetricsInt
-            // keep it the same as paint's fm
-            fm.ascent = pfm.ascent
-            fm.descent = pfm.descent
-            fm.top = pfm.top
-            fm.bottom = pfm.bottom
+        val drawable = drawable
+        val rect = drawable.bounds
+        if (fontMetricsInt != null) {
+            val fmPaint = paint.fontMetricsInt
+            val fontHeight = fmPaint.descent - fmPaint.ascent
+            val drHeight = rect.bottom - rect.top
+            val centerY = fmPaint.ascent + fontHeight / 2
+            fontMetricsInt.ascent = centerY - drHeight / 2
+            fontMetricsInt.top = fontMetricsInt.ascent
+            fontMetricsInt.bottom = centerY + drHeight / 2
+            fontMetricsInt.descent = fontMetricsInt.bottom
         }
         return rect.right
     }
-
     override fun draw(
-        canvas: Canvas,
-        text: CharSequence,
-        start: Int,
-        end: Int,
-        x: Float,
-        top: Int,
-        y: Int,
-        bottom: Int,
-        paint: Paint
+        canvas: Canvas, text: CharSequence?, start: Int, end: Int,
+        x: Float, top: Int, y: Int, bottom: Int, paint: Paint
     ) {
-        val b = cachedDrawable
+        val drawable = drawable
         canvas.save()
-        val drawableHeight = b!!.intrinsicHeight
-        val fontAscent = paint.fontMetricsInt.ascent
-        val fontDescent = paint.fontMetricsInt.descent
-        val transY = bottom - b.bounds.bottom +  // align bottom to bottom
-                (drawableHeight - fontDescent + fontAscent) / 2 // align center to center
+        val fmPaint = paint.fontMetricsInt
+        val fontHeight = fmPaint.descent - fmPaint.ascent
+        val centerY = y + fmPaint.descent - fontHeight / 2
+        val transY = centerY - (drawable.bounds.bottom - drawable.bounds.top) / 2
         canvas.translate(x, transY.toFloat())
-        b.draw(canvas)
+        drawable.draw(canvas)
         canvas.restore()
     }
 
     // Redefined locally because it is a private member from DynamicDrawableSpan
     private val cachedDrawable: Drawable?
-        private get() {
+        get() {
             val wr = mDrawableRef
             var d: Drawable? = null
             if (wr != null) d = wr.get()


### PR DESCRIPTION
This makes chat spacing look much more consistent, which was one of my gripes with the app.
This also brings it more in line with the web twitch chat, where emotes are centered as well.

![Example here](https://github.com/crackededed/Xtra/assets/12669467/c3521458-30de-4e75-916f-539f9fa4f7c9)

I might attempt to update some of the app to Material 3, would that be appreciated?

Thanks for the nice app!