### PR TITLE
Support http url to open app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="*.twitch.tv" />
                 <data android:host="twitch.tv" />


### PR DESCRIPTION
it's not possible to use http url to open app. some streamers use `twitch.tv/channelname` in their notification.
PS: official app allows it