### PR TITLE
Show chat message text on long press

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
@@ -581,7 +581,7 @@ class ChatAdapter(
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     tooltipText = originalMessage
                 } else {
-                    TooltipCompat.setTooltipText(this, originalMessage);
+                    TooltipCompat.setTooltipText(this, originalMessage)
                 }
                 setOnClickListener { messageClickListener?.invoke(originalMessage, formattedMessage, userId, channelId, fullMsg) }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChatAdapter.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
@@ -18,6 +19,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.text.getSpans
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
@@ -576,6 +578,11 @@ class ChatAdapter(
             textView.apply {
                 text = formattedMessage
                 movementMethod = LinkMovementMethod.getInstance()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    tooltipText = originalMessage
+                } else {
+                    TooltipCompat.setTooltipText(this, originalMessage);
+                }
                 setOnClickListener { messageClickListener?.invoke(originalMessage, formattedMessage, userId, channelId, fullMsg) }
             }
         }


### PR DESCRIPTION
When I see an emote I don't recognize, I like to see its name. The only way to do it currently as far I know in Xtra is to copy the chat message to clipboard and paste it somewhere. This would make it so that I can just long press the message and find out.

It's a minor thing, but I feel it's a good quality of life improvement.