### PR TITLE
Adapt username color to the app theme

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/ChatView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/ChatView.kt
@@ -95,6 +95,8 @@ class ChatView : ConstraintLayout {
                 emoteSize = context.convertDpToPixels(29.5f),
                 badgeSize = context.convertDpToPixels(18.5f),
                 randomColor = context.prefs().getBoolean(C.CHAT_RANDOMCOLOR, true),
+                isLightTheme = context.isLightTheme,
+                useThemeAdaptedUsernameColor = context.prefs().getBoolean(C.CHAT_THEME_ADAPTED_USERNAME_COLOR, false),
                 boldNames = context.prefs().getBoolean(C.CHAT_BOLDNAMES, false),
                 emoteQuality = context.prefs().getString(C.CHAT_IMAGE_QUALITY, "4") ?: "4",
                 animateGifs = context.prefs().getBoolean(C.ANIMATED_EMOTES, true),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/ChatView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/chat/ChatView.kt
@@ -96,7 +96,7 @@ class ChatView : ConstraintLayout {
                 badgeSize = context.convertDpToPixels(18.5f),
                 randomColor = context.prefs().getBoolean(C.CHAT_RANDOMCOLOR, true),
                 isLightTheme = context.isLightTheme,
-                useThemeAdaptedUsernameColor = context.prefs().getBoolean(C.CHAT_THEME_ADAPTED_USERNAME_COLOR, false),
+                useThemeAdaptedUsernameColor = context.prefs().getBoolean(C.CHAT_THEME_ADAPTED_USERNAME_COLOR, true),
                 boldNames = context.prefs().getBoolean(C.CHAT_BOLDNAMES, false),
                 emoteQuality = context.prefs().getString(C.CHAT_IMAGE_QUALITY, "4") ?: "4",
                 animateGifs = context.prefs().getBoolean(C.ANIMATED_EMOTES, true),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -152,6 +152,7 @@ object C {
     const val CHAT_IMAGE_LIBRARY = "chat_image_library"
     const val CHAT_IMAGE_QUALITY = "chat_image_quality"
     const val CHAT_RANDOMCOLOR = "chat_randomcolor"
+    const val CHAT_THEME_ADAPTED_USERNAME_COLOR = "chat_theme_adapted_username_color"
     const val CHAT_BOLDNAMES = "chat_boldnames"
     const val CHAT_LIMIT = "chat_limit"
     const val CHAT_ZEROWIDTH = "chat_zerowidth"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Адаптировать цвета пользователей в чате в зависимости от темы</string>
+    <string name="theme_adapted_username_color">Адаптировать цвета в зависимости от темы</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Адаптировать цвета пользователей в чате в зависимости от темы</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -610,5 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -610,4 +610,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,5 +624,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
-    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
+    <string name="theme_adapted_username_color">Readable colors based on the app theme</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,4 +624,5 @@
     <string name="move_to_shared_storage">Move to shared storage</string>
     <string name="move_to_app_storage">Move to app storage</string>
     <string name="download_moving">Moving</string>
+    <string name="theme_adapted_username_color">Adapt username color to the app theme</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -184,6 +184,13 @@
         app:singleLineTitle="false" />
 
     <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="chat_theme_adapted_username_color"
+        android:title="@string/theme_adapted_username_color"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="animatedGifEmotes"
         android:title="@string/animated_emotes"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -184,7 +184,7 @@
         app:singleLineTitle="false" />
 
     <SwitchPreferenceCompat
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="chat_theme_adapted_username_color"
         android:title="@string/theme_adapted_username_color"
         app:iconSpaceReserved="false"


### PR DESCRIPTION
As a user I have difficulties with reading some usernames in the chat. For example, light yellow in the white theme or black in the black theme.

Please, let me know what you think. And what about having it ON by default?