### PR TITLE
declare android:installLocation to auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
Allows the app to be installed/moved to the external storage (e.g. SD card), as per the [docs](https://developer.android.com/guide/topics/data/install-location).

This is useful for users like me who's running out of internal storage space.

Thanks.