### PR TITLE
Update: Bump gradle/actions/wrapper-validation from 2 to 4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: gradle/wrapper-validation-action@v3
+    - uses: gradle/actions/wrapper-validation@v3
     - name: set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: gradle/actions/wrapper-validation@v3
+    - uses: gradle/actions/wrapper-validation@v4
     - name: set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: gradle/wrapper-validation-action@v2
+    - uses: gradle/wrapper-validation-action@v3
     - name: set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
This will update the `gradle/actions/wrapper-validation` to the latest image, as the old image is marked as obsolete. This will change the version used from 2 to 4

The GitHub workflow used should continue to work.