### PR TITLE
Bump github_action dependencies of `update-tag.yml` on `fdroid` branch with 1 update

### DIFF
--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -8,7 +8,7 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Update git tag
       run: |
         git tag -f f-droid


### PR DESCRIPTION
This will update the following github_action dependencies of `update-tag.yml` on `fdroid` branch to the current version of the respective dependency:

Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v5...v6)

The GitHub workflow used should continue to work.