### PR TITLE
per-app language settings for Android 13+

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -71,6 +71,7 @@ object C {
     const val UI_FOLLOWPAGER = "ui_followpager"
     const val UI_SAVED_DEFAULT_PAGE = "ui_saved_default_page"
     const val UI_SAVEDPAGER = "ui_savedpager"
+    const val UI_LANGUAGE_13_OR_UP = "ui_language_13_or_up"
     const val UI_LANGUAGE = "ui_language"
     const val UI_CUTOUTMODE = "ui_cutoutmode"
     const val UI_DRAW_BEHIND_CUTOUTS = "ui_draw_behind_cutouts"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,6 +1,13 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <Preference
+        android:key="ui_language_13_or_up"
+        android:title="@string/language"
+        app:isPreferenceVisible="false"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
     <ListPreference
         android:defaultValue="auto"
         android:entries="@array/languageEntries"


### PR DESCRIPTION
Fix:
- https://github.com/crackededed/Xtra/issues/630
- https://github.com/crackededed/Xtra/issues/681

Reference:
- https://developer.android.com/reference/android/provider/Settings#ACTION_APP_LOCALE_SETTINGS
- https://developer.android.com/guide/topics/resources/app-languages#reset-locale