### PR TITLE
Update android.yml checkout to blobless

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        filter: blob:none
     - name: Setup Java
       uses: actions/setup-java@v5
       with:


### PR DESCRIPTION
Updates the checkout action in `android.yml` to be **blobless**. Blobs are basically file content (more information [here](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/)) so it will now only download the blobs of the commit used to build the APK instead of the entire repo, while remaining compatible with git log.

**Treeless** is possible too but not much faster, and future changes to the workflow could actually make it slower (if forgotten to be updated to blobless).