### PR TITLE
feat: pinch to zoom in video player

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -451,6 +451,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             }
 
             dragView.setOnTouchListener { _, event ->
+                if (binding.playerLayout.onTouchEvent(event)) {
+                    return@setOnTouchListener true
+                }
                 if (!isAnimating) {
                     when (event.actionMasked) {
                         MotionEvent.ACTION_DOWN -> {
@@ -468,7 +471,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 val pointerId = event.getPointerId(pointerIndex)
                                 val x = event.getX(pointerIndex)
                                 val y = event.getY(pointerIndex)
-                                if (x in 0f..playerLayout.width.toFloat() && y in 0f..playerLayout.height.toFloat()) {
+                                if (x in 0f..binding.playerLayout.width.toFloat() && y in 0f..binding.playerLayout.height.toFloat()) {
                                     activePointerId = pointerId
                                     lastX = x * slidingLayout.scaleX
                                     lastY = y * slidingLayout.scaleY

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -250,6 +250,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             val touchSlopRange = -touchSlop.toFloat()..touchSlop.toFloat()
             val longPressTimeout = ViewConfiguration.getLongPressTimeout()
             val moveFreely = requireContext().prefs().getBoolean(C.PLAYER_MOVE_FREELY, false)
+            val pinchToZoom = requireContext().prefs().getBoolean(C.PLAYER_PINCH_TO_ZOOM, false)
+            binding.playerLayout.isZoomEnabled = pinchToZoom
             val doubleTap = requireContext().prefs().getBoolean(C.PLAYER_DOUBLE_TAP, true) && !requireContext().prefs().getBoolean(C.CHAT_DISABLE, false)
             val controllerTapDetector = GestureDetector(
                 requireContext(),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -6,6 +6,8 @@ import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import com.github.andreyasadchy.xtra.R
+import kotlin.math.max
+import kotlin.math.min
 
 class PlayerLayout : FrameLayout {
 
@@ -15,15 +17,38 @@ class PlayerLayout : FrameLayout {
 
     var isPortrait = false
     private var scaleFactor = 1f
+    private var lastTouchX = 0f
+    private var lastTouchY = 0f
+    private var activePointerId = -1
+
     private val scaleGestureDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
         override fun onScale(detector: ScaleGestureDetector): Boolean {
             scaleFactor *= detector.scaleFactor
             scaleFactor = scaleFactor.coerceIn(1f, 3f)
-            findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)?.scaleX = scaleFactor
-            findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)?.scaleY = scaleFactor
+            
+            val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)
+            view?.scaleX = scaleFactor
+            view?.scaleY = scaleFactor
+            
+            // Constrain translation after scaling
+            applyConstraints(view)
             return true
         }
     })
+
+    private fun applyConstraints(view: FrameLayout?) {
+        if (view == null || scaleFactor <= 1f) {
+            view?.translationX = 0f
+            view?.translationY = 0f
+            return
+        }
+
+        val maxTranslationX = (view.width * (scaleFactor - 1f)) / 2f
+        val maxTranslationY = (view.height * (scaleFactor - 1f)) / 2f
+        
+        view.translationX = view.translationX.coerceIn(-maxTranslationX, maxTranslationX)
+        view.translationY = view.translationY.coerceIn(-maxTranslationY, maxTranslationY)
+    }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -38,6 +63,36 @@ class PlayerLayout : FrameLayout {
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         scaleGestureDetector.onTouchEvent(event)
+        
+        val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return true
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                activePointerId = event.getPointerId(0)
+                lastTouchX = event.x
+                lastTouchY = event.y
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (!scaleGestureDetector.isInProgress && scaleFactor > 1f) {
+                    val pointerIndex = event.findPointerIndex(activePointerId)
+                    if (pointerIndex != -1) {
+                        val x = event.getX(pointerIndex)
+                        val y = event.getY(pointerIndex)
+                        
+                        view.translationX += (x - lastTouchX)
+                        view.translationY += (y - lastTouchY)
+                        
+                        applyConstraints(view)
+                        
+                        lastTouchX = x
+                        lastTouchY = y
+                    }
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                activePointerId = -1
+            }
+        }
         return true
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -15,6 +15,7 @@ class PlayerLayout : FrameLayout {
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     var isPortrait = false
+    var isZoomEnabled = false
     var scaleFactor = 1f
         private set
     private var lastScaleFactor = 1f
@@ -89,6 +90,8 @@ class PlayerLayout : FrameLayout {
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (!isZoomEnabled) return false
+
         scaleGestureDetector.onTouchEvent(event)
         doubleTapGestureDetector.onTouchEvent(event)
         

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -16,12 +16,13 @@ class PlayerLayout : FrameLayout {
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     var isPortrait = false
-    private var scaleFactor = 1f
+    var scaleFactor = 1f
+        private set
     private var lastTouchX = 0f
     private var lastTouchY = 0f
     private var activePointerId = -1
 
-    private val scaleGestureDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+    val scaleGestureDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
         override fun onScale(detector: ScaleGestureDetector): Boolean {
             scaleFactor *= detector.scaleFactor
             scaleFactor = scaleFactor.coerceIn(1f, 3f)
@@ -50,21 +51,10 @@ class PlayerLayout : FrameLayout {
         view.translationY = view.translationY.coerceIn(-maxTranslationY, maxTranslationY)
     }
 
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (isPortrait) {
-            val playerHeight = (measuredWidth / (16f / 9f)).toInt()
-            super.onMeasure(
-                widthMeasureSpec,
-                MeasureSpec.makeMeasureSpec(playerHeight, MeasureSpec.EXACTLY)
-            )
-        }
-    }
-
     override fun onTouchEvent(event: MotionEvent): Boolean {
         scaleGestureDetector.onTouchEvent(event)
         
-        val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return true
+        val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return false
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
@@ -86,6 +76,7 @@ class PlayerLayout : FrameLayout {
                         
                         lastTouchX = x
                         lastTouchY = y
+                        return true // Pan handled
                     }
                 }
             }
@@ -93,11 +84,17 @@ class PlayerLayout : FrameLayout {
                 activePointerId = -1
             }
         }
-        return true
+        return scaleGestureDetector.isInProgress || scaleFactor > 1f
     }
 
-    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-        scaleGestureDetector.onTouchEvent(ev)
-        return super.onInterceptTouchEvent(ev)
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        if (isPortrait) {
+            val playerHeight = (measuredWidth / (16f / 9f)).toInt()
+            super.onMeasure(
+                widthMeasureSpec,
+                MeasureSpec.makeMeasureSpec(playerHeight, MeasureSpec.EXACTLY)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -2,12 +2,11 @@ package com.github.andreyasadchy.xtra.ui.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import com.github.andreyasadchy.xtra.R
-import kotlin.math.max
-import kotlin.math.min
 
 class PlayerLayout : FrameLayout {
 
@@ -18,6 +17,9 @@ class PlayerLayout : FrameLayout {
     var isPortrait = false
     var scaleFactor = 1f
         private set
+    private var lastScaleFactor = 1f
+    private var lastTranslationX = 0f
+    private var lastTranslationY = 0f
     private var lastTouchX = 0f
     private var lastTouchY = 0f
     private var activePointerId = -1
@@ -31,8 +33,32 @@ class PlayerLayout : FrameLayout {
             view?.scaleX = scaleFactor
             view?.scaleY = scaleFactor
             
-            // Constrain translation after scaling
             applyConstraints(view)
+            return true
+        }
+    })
+
+    private val doubleTapGestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+        override fun onDoubleTap(e: MotionEvent): Boolean {
+            val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return false
+            if (scaleFactor > 1f) {
+                lastScaleFactor = scaleFactor
+                lastTranslationX = view.translationX
+                lastTranslationY = view.translationY
+                
+                scaleFactor = 1f
+                view.scaleX = scaleFactor
+                view.scaleY = scaleFactor
+                view.translationX = 0f
+                view.translationY = 0f
+            } else {
+                scaleFactor = if (lastScaleFactor > 1f) lastScaleFactor else 2f
+                view.scaleX = scaleFactor
+                view.scaleY = scaleFactor
+                view.translationX = lastTranslationX
+                view.translationY = lastTranslationY
+                applyConstraints(view)
+            }
             return true
         }
     })
@@ -51,8 +77,20 @@ class PlayerLayout : FrameLayout {
         view.translationY = view.translationY.coerceIn(-maxTranslationY, maxTranslationY)
     }
 
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        if (isPortrait) {
+            val playerHeight = (measuredWidth / (16f / 9f)).toInt()
+            super.onMeasure(
+                widthMeasureSpec,
+                MeasureSpec.makeMeasureSpec(playerHeight, MeasureSpec.EXACTLY)
+            )
+        }
+    }
+
     override fun onTouchEvent(event: MotionEvent): Boolean {
         scaleGestureDetector.onTouchEvent(event)
+        doubleTapGestureDetector.onTouchEvent(event)
         
         val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return false
 
@@ -76,7 +114,7 @@ class PlayerLayout : FrameLayout {
                         
                         lastTouchX = x
                         lastTouchY = y
-                        return true // Pan handled
+                        return true
                     }
                 }
             }
@@ -85,16 +123,5 @@ class PlayerLayout : FrameLayout {
             }
         }
         return scaleGestureDetector.isInProgress || scaleFactor > 1f
-    }
-
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (isPortrait) {
-            val playerHeight = (measuredWidth / (16f / 9f)).toInt()
-            super.onMeasure(
-                widthMeasureSpec,
-                MeasureSpec.makeMeasureSpec(playerHeight, MeasureSpec.EXACTLY)
-            )
-        }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -19,8 +19,10 @@ class PlayerLayout : FrameLayout {
     var scaleFactor = 1f
         private set
     private var lastScaleFactor = 1f
-    private var lastTranslationX = 0f
-    private var lastTranslationY = 0f
+    private var normalizedTranslationX = 0f
+    private var normalizedTranslationY = 0f
+    private var lastNormalizedTranslationX = 0f
+    private var lastNormalizedTranslationY = 0f
     private var lastTouchX = 0f
     private var lastTouchY = 0f
     private var activePointerId = -1
@@ -38,44 +40,79 @@ class PlayerLayout : FrameLayout {
             return true
         }
     })
+private val doubleTapGestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+    override fun onDoubleTap(e: MotionEvent): Boolean {
+        val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return false
+        if (scaleFactor > 1f) {
+            lastScaleFactor = scaleFactor
+            lastNormalizedTranslationX = normalizedTranslationX
+            lastNormalizedTranslationY = normalizedTranslationY
 
-    private val doubleTapGestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
-        override fun onDoubleTap(e: MotionEvent): Boolean {
-            val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout) ?: return false
-            if (scaleFactor > 1f) {
-                lastScaleFactor = scaleFactor
-                lastTranslationX = view.translationX
-                lastTranslationY = view.translationY
-                
-                scaleFactor = 1f
-                view.scaleX = scaleFactor
-                view.scaleY = scaleFactor
-                view.translationX = 0f
-                view.translationY = 0f
-            } else {
-                scaleFactor = if (lastScaleFactor > 1f) lastScaleFactor else 2f
-                view.scaleX = scaleFactor
-                view.scaleY = scaleFactor
-                view.translationX = lastTranslationX
-                view.translationY = lastTranslationY
-                applyConstraints(view)
-            }
-            return true
+            scaleFactor = 1f
+            view.scaleX = scaleFactor
+            view.scaleY = scaleFactor
+            view.translationX = 0f
+            view.translationY = 0f
+            normalizedTranslationX = 0f
+            normalizedTranslationY = 0f
+        } else {
+            scaleFactor = if (lastScaleFactor > 1f) lastScaleFactor else 2f
+            view.scaleX = scaleFactor
+            view.scaleY = scaleFactor
+
+            normalizedTranslationX = lastNormalizedTranslationX
+            normalizedTranslationY = lastNormalizedTranslationY
+
+            val maxTranslationX = (view.width * (scaleFactor - 1f)) / 2f
+            val maxTranslationY = (view.height * (scaleFactor - 1f)) / 2f
+            view.translationX = normalizedTranslationX * maxTranslationX
+            view.translationY = normalizedTranslationY * maxTranslationY
+
+            applyConstraints(view)
         }
-    })
-
+        return true
+    }
+})
     private fun applyConstraints(view: FrameLayout?) {
-        if (view == null || scaleFactor <= 1f) {
-            view?.translationX = 0f
-            view?.translationY = 0f
+        if (view == null) return
+        
+        if (scaleFactor <= 1f) {
+            view.translationX = 0f
+            view.translationY = 0f
+            normalizedTranslationX = 0f
+            normalizedTranslationY = 0f
             return
         }
 
         val maxTranslationX = (view.width * (scaleFactor - 1f)) / 2f
         val maxTranslationY = (view.height * (scaleFactor - 1f)) / 2f
         
-        view.translationX = view.translationX.coerceIn(-maxTranslationX, maxTranslationX)
-        view.translationY = view.translationY.coerceIn(-maxTranslationY, maxTranslationY)
+        if (maxTranslationX > 0) {
+            view.translationX = view.translationX.coerceIn(-maxTranslationX, maxTranslationX)
+            normalizedTranslationX = view.translationX / maxTranslationX
+        } else {
+            view.translationX = 0f
+            normalizedTranslationX = 0f
+        }
+        
+        if (maxTranslationY > 0) {
+            view.translationY = view.translationY.coerceIn(-maxTranslationY, maxTranslationY)
+            normalizedTranslationY = view.translationY / maxTranslationY
+        } else {
+            view.translationY = 0f
+            normalizedTranslationY = 0f
+        }
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        val view = findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)
+        if (view != null && scaleFactor > 1f) {
+            val maxTranslationX = (view.width * (scaleFactor - 1f)) / 2f
+            val maxTranslationY = (view.height * (scaleFactor - 1f)) / 2f
+            view.translationX = normalizedTranslationX * maxTranslationX
+            view.translationY = normalizedTranslationY * maxTranslationY
+        }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/PlayerLayout.kt
@@ -2,7 +2,10 @@ package com.github.andreyasadchy.xtra.ui.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
+import com.github.andreyasadchy.xtra.R
 
 class PlayerLayout : FrameLayout {
 
@@ -11,6 +14,16 @@ class PlayerLayout : FrameLayout {
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     var isPortrait = false
+    private var scaleFactor = 1f
+    private val scaleGestureDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            scaleFactor *= detector.scaleFactor
+            scaleFactor = scaleFactor.coerceIn(1f, 3f)
+            findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)?.scaleX = scaleFactor
+            findViewById<FrameLayout>(R.id.aspectRatioFrameLayout)?.scaleY = scaleFactor
+            return true
+        }
+    })
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -21,5 +34,15 @@ class PlayerLayout : FrameLayout {
                 MeasureSpec.makeMeasureSpec(playerHeight, MeasureSpec.EXACTLY)
             )
         }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        scaleGestureDetector.onTouchEvent(event)
+        return true
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        scaleGestureDetector.onTouchEvent(ev)
+        return super.onInterceptTouchEvent(ev)
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -180,6 +180,7 @@ object C {
     const val PLAYER_HANDLE_AUDIO_BECOMING_NOISY = "player_handle_audio_becoming_noisy"
     const val PLAYER_ROUNDED_CORNER_PADDING = "player_rounded_corner_padding"
     const val PLAYER_MOVE_FREELY = "player_move_freely"
+    const val PLAYER_PINCH_TO_ZOOM = "player_pinch_to_zoom"
     const val PLAYER_KEEP_CHAT_OPEN = "player_keep_chat_open"
     const val PLAYER_HIDE_ADS = "player_hide_ads"
     const val PLAYER_PROXY = "player_proxy"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -660,6 +660,7 @@
     <string name="use_webp_images">Use WebP images</string>
     <string name="use_background_audio">Play audio in the background</string>
     <string name="avoid_rounded_corners">Avoid rounded screen corners</string>
+    <string name="pinch_to_zoom">Pinch to zoom</string>
     <string name="api_web_gql_token">Web GQL token</string>
     <string name="chat_size_modifier">Size modifier</string>
     <string name="chat_emote_size">Emote size</string>

--- a/app/src/main/res/xml/player_preferences.xml
+++ b/app/src/main/res/xml/player_preferences.xml
@@ -79,6 +79,13 @@
 
     <SwitchPreferenceCompat
         android:defaultValue="false"
+        android:key="player_pinch_to_zoom"
+        android:title="@string/pinch_to_zoom"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
         android:key="player_move_freely"
         android:title="@string/move_player_freely"
         app:iconSpaceReserved="false"


### PR DESCRIPTION
This allows the user to pinch to zoom in the stream/video player. It also allows quick double-tap to go switched between zoomed-in view and fullscreen. It is completely disabled by default and can be turned on in the Player settings.
I tested all of this thoroughly on my phone. 
