### PR TITLE
update default VOD expiration delay to 7 days instead of 14

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksAdapter.kt
@@ -173,9 +173,9 @@ class BookmarksAdapter(
                     if (item.type?.lowercase() == "archive" && userType != null && item.createdAt != null && context.prefs().getBoolean(C.UI_BOOKMARK_TIME_LEFT, true) && !ignore) {
                         val text = Instant.parseOrNull(item.createdAt)?.takeIf { time -> time.toEpochMilliseconds() > 0 }?.let { createdAt ->
                             val days = when (userType.lowercase()) {
-                                "" -> 14
+                                "" -> 7
                                 "affiliate" -> 14
-                                else -> 60
+                                else -> 60 // Partners, Prime, Turbo
                             }
                             val timeLeft = (createdAt + days.days) - Clock.System.now()
                             if (timeLeft.isPositive()) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksFragment.kt
@@ -158,9 +158,9 @@ class BookmarksFragment : BaseNetworkFragment(), Scrollable, Sortable, Bookmarks
                                     if (userType != null && it.createdAt != null) {
                                         Instant.parseOrNull(it.createdAt)?.takeIf { time -> time.toEpochMilliseconds() > 0 }?.let { time ->
                                             val days = when (userType.lowercase()) {
-                                                "" -> 14
+                                                "" -> 7
                                                 "affiliate" -> 14
-                                                else -> 60
+                                                else -> 60 // Partners, Prime, Turbo
                                             }
                                             val timeLeft = (time + days.days) - Clock.System.now()
                                             if (timeLeft.isPositive()) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksFragment.kt
@@ -183,9 +183,9 @@ class BookmarksFragment : BaseNetworkFragment(), Scrollable, Sortable, Bookmarks
                                     if (userType != null && it.createdAt != null) {
                                         Instant.parseOrNull(it.createdAt)?.takeIf { time -> time.toEpochMilliseconds() > 0 }?.let { time ->
                                             val days = when (userType.lowercase()) {
-                                                "" -> 14
+                                                "" -> 7
                                                 "affiliate" -> 14
-                                                else -> 60
+                                                else -> 60 // Partners, Prime, Turbo
                                             }
                                             val timeLeft = (time + days.days) - Clock.System.now()
                                             if (timeLeft.isPositive()) {


### PR DESCRIPTION
And add comment about who falls into the 60 days case

https://help.twitch.tv/s/article/video-on-demand?language=en_US

> All other broadcasters will have their past broadcasts saved for 7 days before they are deleted.

It might be why I had a few surprises with lost VODs with smaller streamers, but not sure.