### PR TITLE
Fix live notifications with Helix fallback

### DIFF
--- a/app/src/main/graphql/UserFollowedUsers.graphql
+++ b/app/src/main/graphql/UserFollowedUsers.graphql
@@ -7,6 +7,13 @@ query UserFollowedUsers($first: Int, $after: Cursor) {
                 node {
                     displayName
                     id
+                    self {
+                        follower {
+                            notificationSettings {
+                                isEnabled
+                            }
+                        }
+                    }
                     lastBroadcast {
                         startedAt
                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/NotificationUsersDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/NotificationUsersDao.kt
@@ -3,7 +3,9 @@ package com.github.andreyasadchy.xtra.db
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.github.andreyasadchy.xtra.model.NotificationUser
 
 @Dao
@@ -15,9 +17,21 @@ interface NotificationUsersDao {
     @Query("SELECT * FROM notifications WHERE channelId = :id")
     fun getById(id: String): NotificationUser?
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(item: NotificationUser)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertList(items: List<NotificationUser>)
 
     @Delete
     fun delete(item: NotificationUser)
+
+    @Query("DELETE FROM notifications")
+    fun deleteAll()
+
+    @Transaction
+    fun replaceAll(items: List<NotificationUser>) {
+        deleteAll()
+        insertList(items)
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/NotificationsRepository.kt
@@ -6,6 +6,7 @@ import com.github.andreyasadchy.xtra.model.NotificationUser
 import com.github.andreyasadchy.xtra.model.ShownNotification
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.util.C
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.time.Instant
@@ -19,28 +20,41 @@ class NotificationsRepository(
 
     suspend fun getNewStreams(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>): List<Stream> = withContext(Dispatchers.IO) {
         val list = mutableListOf<Stream>()
-        notificationUsersDao.getAll().map { it.channelId }.takeIf { it.isNotEmpty() }?.let {
-            try {
-                gqlQueryLocal(networkLibrary, gqlHeaders, it)
-            } catch (e: Exception) {
-                if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                    try {
-                        helixLocal(networkLibrary, helixHeaders, it)
-                    } catch (e: Exception) {
-                        return@withContext emptyList()
+        val notificationIds = notificationUsersDao.getAll().map { it.channelId }
+        if (notificationIds.isNotEmpty() &&
+            gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() &&
+            helixHeaders[C.HEADER_TOKEN].isNullOrBlank()
+        ) {
+            return@withContext emptyList()
+        }
+        if (notificationIds.isNotEmpty()) {
+            val localStreams = if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                try {
+                    gqlQueryLocal(networkLibrary, gqlHeaders, notificationIds)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (gqlException: Exception) {
+                    if (helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                        throw gqlException
                     }
-                } else return@withContext emptyList()
-            }.let { list.addAll(it) }
+                    helixLocal(networkLibrary, helixHeaders, notificationIds)
+                }
+            } else {
+                helixLocal(networkLibrary, helixHeaders, notificationIds)
+            }
+            list.addAll(localStreams)
         }
         if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             try {
                 gqlQueryLoad(networkLibrary, gqlHeaders)
+                    .filterNot { item -> list.any { it.channelId == item.channelId } }
+                    .let(list::addAll)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                return@withContext emptyList()
-            }.mapNotNull { item ->
-                item.takeIf { list.find { it.channelId == item.channelId } == null }
-            }.let {
-                list.addAll(it)
+                if (list.isEmpty()) {
+                    throw e
+                }
             }
         }
         val liveList = list.mapNotNull { stream ->
@@ -59,6 +73,28 @@ class NotificationsRepository(
             item.takeIf { oldList.find { it.channelId == item.channelId }.let { it == null || it.startedAt < item.startedAt } }?.channelId
         }
         list.filter { it.channelId in newStreams }
+    }
+
+    suspend fun syncNotificationUsers(networkLibrary: String?, gqlHeaders: Map<String, String>) = withContext(Dispatchers.IO) {
+        if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            return@withContext false
+        }
+        val users = mutableListOf<NotificationUser>()
+        var offset: String? = null
+        do {
+            val response = graphQLRepository.loadQueryUserFollowedUsers(networkLibrary, gqlHeaders, 100, offset)
+            response.errors?.firstOrNull()?.let { throw Exception(it.message) }
+            val data = response.data!!.user!!.follows!!
+            val items = data.edges!!
+            users.addAll(items.mapNotNull { item ->
+                item?.node?.takeIf {
+                    it.self?.follower?.notificationSettings?.isEnabled == true
+                }?.id?.let(::NotificationUser)
+            })
+            offset = items.lastOrNull()?.cursor?.toString()
+        } while (!offset.isNullOrBlank() && data.pageInfo?.hasNextPage == true)
+        notificationUsersDao.replaceAll(users)
+        true
     }
 
     private suspend fun gqlQueryLoad(networkLibrary: String?, gqlHeaders: Map<String, String>): List<Stream> {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -178,6 +178,7 @@ class ChannelPagerViewModel(
                         if (!errorMessage.isNullOrBlank()) {
                             notifications.value = Pair(true, errorMessage)
                         } else {
+                            notificationsRepository.saveUser(NotificationUser(channelId))
                             _notificationsEnabled.value = true
                             notifications.value = Pair(true, errorMessage)
                             if (notificationsEnabled) {
@@ -223,6 +224,7 @@ class ChannelPagerViewModel(
                         if (!errorMessage.isNullOrBlank()) {
                             notifications.value = Pair(false, errorMessage)
                         } else {
+                            notificationsRepository.deleteUser(NotificationUser(channelId))
                             _notificationsEnabled.value = false
                             notifications.value = Pair(false, errorMessage)
                         }
@@ -289,7 +291,10 @@ class ChannelPagerViewModel(
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
                             if (!disableNotifications) {
+                                notificationsRepository.saveUser(NotificationUser(channelId))
                                 _notificationsEnabled.value = true
+                            } else {
+                                notificationsRepository.deleteUser(NotificationUser(channelId))
                             }
                             if (liveNotificationsEnabled) {
                                 _stream.value?.createdAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -341,6 +346,7 @@ class ChannelPagerViewModel(
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
                             _notificationsEnabled.value = false
+                            notificationsRepository.deleteUser(NotificationUser(channelId))
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationWorker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationWorker.kt
@@ -1,39 +1,45 @@
 package com.github.andreyasadchy.xtra.ui.main
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
-import com.github.andreyasadchy.xtra.XtraModule
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
+import kotlinx.coroutines.CancellationException
 
 class LiveNotificationWorker(
     private val context: Context,
     parameters: WorkerParameters,
 ) : CoroutineWorker(context, parameters) {
 
-    lateinit var xtraModule: XtraModule
-
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     override suspend fun doWork(): Result {
-        xtraModule = (context as XtraApp).xtraModule
-        val streams = xtraModule.notificationsRepository.getNewStreams(
-            networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-            gqlHeaders = TwitchApiHelper.getGQLHeaders(context, true),
-            helixHeaders = TwitchApiHelper.getHelixHeaders(context),
-        )
-        if (streams.isNotEmpty()) {
+        val streams = try {
+            (context as XtraApp).xtraModule.notificationsRepository.getNewStreams(
+                networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                gqlHeaders = TwitchApiHelper.getGQLHeaders(context, true),
+                helixHeaders = TwitchApiHelper.getHelixHeaders(context),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            return Result.retry()
+        }
+        if (streams.isNotEmpty() && canPostNotifications()) {
             val channelId = context.getString(R.string.notification_live_channel_id)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 if (notificationManager.getNotificationChannel(channelId) == null) {
@@ -89,6 +95,11 @@ class LiveNotificationWorker(
         }
         return Result.success()
     }
+
+    private fun canPostNotifications() =
+        (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) &&
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
 
     companion object {
         const val GROUP_KEY = "com.github.andreyasadchy.xtra.LIVE_NOTIFICATIONS"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -63,6 +63,7 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ActivityMainBinding
 import com.github.andreyasadchy.xtra.databinding.DialogUpdateDownloadBinding
 import com.github.andreyasadchy.xtra.model.PlaybackState
@@ -98,6 +99,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.color.MaterialColors
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.chromium.net.CronetProvider
 import java.util.Timer
@@ -609,6 +611,33 @@ class MainActivity : AppCompatActivity() {
                     )
                     .build()
             )
+            syncNotificationUsers()
+        }
+    }
+
+    private fun syncNotificationUsers() {
+        val userId = tokenPrefs().getString(C.USER_ID, null) ?: return
+        if (prefs.getString(C.LIVE_NOTIFICATION_USERS_SYNCED, null) == userId) {
+            return
+        }
+        val gqlHeaders = TwitchApiHelper.getGQLHeaders(this, true)
+        if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            return
+        }
+        lifecycleScope.launch {
+            try {
+                val synced = (application as XtraApp).xtraModule.notificationsRepository.syncNotificationUsers(
+                    networkLibrary = prefs.getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                    gqlHeaders = gqlHeaders,
+                )
+                if (synced) {
+                    prefs.edit { putString(C.LIVE_NOTIFICATION_USERS_SYNCED, userId) }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // The worker will retry notification checks without blocking app startup.
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -650,6 +650,11 @@ class Media3PlayerViewModel(
                         } else {
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
+                            if (!disableNotifications) {
+                                notificationsRepository.saveUser(NotificationUser(channelId))
+                            } else {
+                                notificationsRepository.deleteUser(NotificationUser(channelId))
+                            }
                             if (liveNotificationsEnabled) {
                                 startedAt.takeUnless { it.isNullOrBlank() }?.let {
                                     Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }
@@ -698,6 +703,7 @@ class Media3PlayerViewModel(
                         } else {
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
+                            notificationsRepository.deleteUser(NotificationUser(channelId))
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
@@ -475,6 +475,11 @@ class PlayerViewModel(
                         } else {
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
+                            if (!disableNotifications) {
+                                notificationsRepository.saveUser(NotificationUser(channelId))
+                            } else {
+                                notificationsRepository.deleteUser(NotificationUser(channelId))
+                            }
                             if (liveNotificationsEnabled) {
                                 startedAt.takeUnless { it.isNullOrBlank() }?.let {
                                     Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }
@@ -523,6 +528,7 @@ class PlayerViewModel(
                         } else {
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
+                            notificationsRepository.deleteUser(NotificationUser(channelId))
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -252,6 +252,7 @@ class SettingsActivity : AppCompatActivity() {
         private val viewModel: SettingsViewModel by activityViewModels { SettingsViewModelFactory }
         private var backupResultLauncher: ActivityResultLauncher<Intent>? = null
         private var restoreResultLauncher: ActivityResultLauncher<Intent>? = null
+        private lateinit var notificationPermissionLauncher: ActivityResultLauncher<String>
         private var updateDownloadDialogBinding: DialogUpdateDownloadBinding? = null
         private var updateDownloadDialog: AlertDialog? = null
 
@@ -285,6 +286,23 @@ class SettingsActivity : AppCompatActivity() {
                     )
                 }
             }
+            notificationPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+                if (granted) {
+                    findPreference<SwitchPreferenceCompat>("live_notifications_enabled")?.let {
+                        it.isChecked = true
+                        toggleLiveNotifications(true)
+                    }
+                }
+            }
+        }
+
+        private fun toggleLiveNotifications(enabled: Boolean) {
+            viewModel.toggleNotifications(
+                enabled = enabled,
+                networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                gqlHeaders = TwitchApiHelper.getGQLHeaders(requireContext(), true),
+                helixHeaders = TwitchApiHelper.getHelixHeaders(requireContext())
+            )
         }
 
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -338,18 +356,16 @@ class SettingsActivity : AppCompatActivity() {
                 }
             }
             findPreference<SwitchPreferenceCompat>("live_notifications_enabled")?.setOnPreferenceChangeListener { _, newValue ->
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                val enabled = newValue as Boolean
+                if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                     ActivityCompat.checkSelfPermission(requireActivity(), Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
                 ) {
-                    ActivityCompat.requestPermissions(requireActivity(), arrayOf(Manifest.permission.POST_NOTIFICATIONS), 1)
+                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    false
+                } else {
+                    toggleLiveNotifications(enabled)
+                    true
                 }
-                viewModel.toggleNotifications(
-                    enabled = newValue as Boolean,
-                    networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-                    gqlHeaders = TwitchApiHelper.getGQLHeaders(requireContext(), true),
-                    helixHeaders = TwitchApiHelper.getHelixHeaders(requireContext())
-                )
-                true
             }
             findPreference<Preference>("theme_settings")?.setOnPreferenceClickListener {
                 requireActivity().findViewById<AppBarLayout>(R.id.appBar)?.setExpanded(true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import android.net.http.HttpEngine
 import android.provider.DocumentsContract
 import android.util.JsonReader
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModel
@@ -35,9 +36,12 @@ import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
+import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
 import com.github.andreyasadchy.xtra.util.m3u8.Segment
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -489,7 +493,6 @@ class SettingsViewModel(
     fun toggleNotifications(enabled: Boolean, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>) {
         viewModelScope.launch(Dispatchers.IO) {
             if (enabled) {
-                notificationsRepository.getNewStreams(networkLibrary, gqlHeaders, helixHeaders)
                 WorkManager.getInstance(applicationContext).enqueueUniquePeriodicWork(
                     "live_notifications",
                     ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
@@ -502,6 +505,20 @@ class SettingsViewModel(
                         )
                         .build()
                 )
+                try {
+                    if (notificationsRepository.syncNotificationUsers(networkLibrary, gqlHeaders)) {
+                        applicationContext.tokenPrefs().getString(C.USER_ID, null)?.let { userId ->
+                            applicationContext.prefs().edit {
+                                putString(C.LIVE_NOTIFICATION_USERS_SYNCED, userId)
+                            }
+                        }
+                    }
+                    notificationsRepository.getNewStreams(networkLibrary, gqlHeaders, helixHeaders)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // The worker will retry after a transient API failure.
+                }
             } else {
                 WorkManager.getInstance(applicationContext).cancelUniqueWork("live_notifications")
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -268,6 +268,7 @@ object C {
     const val UPDATE_CHECK_FREQUENCY = "update_check_frequency"
     const val UPDATE_USE_BROWSER = "update_use_browser"
     const val LIVE_NOTIFICATIONS_ENABLED = "live_notifications_enabled"
+    const val LIVE_NOTIFICATION_USERS_SYNCED = "live_notification_users_synced"
     const val NETWORK_LIBRARY = "network_library"
     const val PLAYER = "player"
     const val DEBUG_CHAT_FULL_MSG = "debug_chat_fullmsg"


### PR DESCRIPTION
Make live notifications fall back to Helix request method, to at least get 15min delayed live notifications instead of none.